### PR TITLE
Use artifacts to display bike activities

### DIFF
--- a/.github/workflows/update-activities.yml
+++ b/.github/workflows/update-activities.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           name: activities-static
           path: static
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: static
           
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/update-activities.yml
+++ b/.github/workflows/update-activities.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Run every Sunday at 23:00 GMT (11 PM)
     - cron: '0 23 * * 0'
-  workflow_dispatch: # Allow manual triggering for testing
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -33,38 +33,28 @@ jobs:
           STRAVA_ACCESS_TOKEN: ${{ secrets.STRAVA_ACCESS_TOKEN }}
         run: npm run fetch-activities
         
-      - name: Commit updated activities
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add static/activities.json
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "Update Strava activities data - $(date)"
-            git push
-          fi
+      - name: Upload activities artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: activities-static
+          path: static
 
   deploy-pages:
     needs: update-activities
     runs-on: ubuntu-latest
     
     steps:
-      - name: Checkout repository (with latest changes)
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          
-      - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
         
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
         
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Download activities artifact
+        uses: actions/download-artifact@v5
         with:
-          path: ./static
+          name: activities-static
+          path: static
           
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for updating and deploying Strava activities data. The main improvements are switching from direct commits to using artifacts for data transfer, and updating action versions for better reliability and maintainability.

**Workflow improvements:**

* Replaced the step that directly commits changes to `static/activities.json` with a step that uploads the entire `static` directory as an artifact using `actions/upload-artifact@v4`. This makes the workflow more robust and avoids potential issues with git operations in CI.
* In the deploy job, removed unnecessary git commands and switched to downloading the previously uploaded artifact using `actions/download-artifact@v5`, ensuring the latest activities data is used for deployment.

**Maintenance and reliability:**

* Updated the `actions/configure-pages` step from version 4 to version 5 for improved reliability and support.
* Minor formatting change in the workflow trigger configuration for clarity; no functional impact.