### PR TITLE
Use refresh token to get Strava activities

### DIFF
--- a/.github/workflows/update-activities.yaml
+++ b/.github/workflows/update-activities.yaml
@@ -30,7 +30,9 @@ jobs:
         
       - name: Fetch Strava activities
         env:
-          STRAVA_ACCESS_TOKEN: ${{ secrets.STRAVA_ACCESS_TOKEN }}
+          STRAVA_CLIENT_ID: ${{ vars.STRAVA_CLIENT_ID }}
+          STRAVA_CLIENT_SECRET: ${{ secrets.STRAVA_CLIENT_SECRET }}
+          STRAVA_REFRESH_TOKEN: ${{ secrets.STRAVA_REFRESH_TOKEN }}
         run: npm run fetch-activities
         
       - name: Upload activities artifact

--- a/scripts/fetch-activities.ts
+++ b/scripts/fetch-activities.ts
@@ -1,18 +1,18 @@
 /**
  * Strava Activities Fetcher for GitHub Pages
- * 
+ *
  * This script fetches cycling activities from the Strava API and generates
  * a static JSON file for the GitHub Pages site.
- * 
+ *
  * Filters for activities containing "terminus" in name or description,
  * and fetches activities after March 22, 2025.
- * 
+ *
  * Run by GitHub Actions weekly on Sundays at 23:00 GMT.
  */
 
-import { writeFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import {writeFileSync} from 'fs';
+import {dirname, join} from 'path';
+import {fileURLToPath} from 'url';
 import fetch from 'node-fetch';
 
 // ES module replacement for __dirname
@@ -20,120 +20,154 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 interface StravaActivity {
-  id: number;
-  name: string;
-  description?: string;
-  start_date: string;
-  distance?: number;
-  moving_time?: number;
-  total_elevation_gain?: number;
-  [key: string]: any;
+    id: number;
+    name: string;
+    description?: string;
+    start_date: string;
+    distance?: number;
+    moving_time?: number;
+    total_elevation_gain?: number;
+
+    [key: string]: any;
+}
+
+/**
+ * Fetch access token using refresh token from Strava API
+ */
+async function getAccessToken(): Promise<string> {
+    const clientId =  process.env.STRAVA_CLIENT_ID;
+    const clientSecret = process.env.STRAVA_CLIENT_SECRET;
+    const refreshToken = process.env.STRAVA_REFRESH_TOKEN;
+
+    if (!clientId || !clientSecret || !refreshToken) {
+        throw new Error('Missing Strava OAuth environment variables');
+    }
+
+    const response = await fetch('https://www.strava.com/oauth/token', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            client_id: clientId,
+            client_secret: clientSecret,
+            refresh_token: refreshToken,
+            grant_type: 'refresh_token'
+        })
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to refresh access token: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json() as { access_token: string };
+    return data.access_token;
 }
 
 /**
  * Fetch a single page of activities from Strava API
  */
 async function fetchActivitiesPage(token: string, page: number): Promise<StravaActivity[]> {
-  const url = new URL('https://www.strava.com/api/v3/athlete/activities');
-  url.searchParams.set('per_page', '200');
-  url.searchParams.set('page', page.toString());
-  
-  // Add date range: after March 22, 2025, before now
-  const marchStart = Math.floor(new Date('2025-03-22T00:00:00Z').getTime() / 1000);
-  const now = Math.floor(Date.now() / 1000);
-  url.searchParams.set('after', marchStart.toString());
-  url.searchParams.set('before', now.toString());
+    const url = new URL('https://www.strava.com/api/v3/athlete/activities');
+    url.searchParams.set('per_page', '200');
+    url.searchParams.set('page', page.toString());
 
-  const response = await fetch(url.toString(), {
-    headers: {
-      'Authorization': `Bearer ${token}`,
-      'Accept-Encoding': 'gzip'
+    // Add date range: after March 22, 2025, before now
+    const marchStart = Math.floor(new Date('2025-03-22T00:00:00Z').getTime() / 1000);
+    const now = Math.floor(Date.now() / 1000);
+    url.searchParams.set('after', marchStart.toString());
+    url.searchParams.set('before', now.toString());
+
+    const response = await fetch(url.toString(), {
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept-Encoding': 'gzip'
+        }
+    });
+
+    if (!response.ok) {
+        throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
     }
-  });
 
-  if (!response.ok) {
-    throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
-  }
-
-  return await response.json() as StravaActivity[];
+    return await response.json() as StravaActivity[];
 }
 
 /**
  * Fetch all activities from Strava API using parallel requests
  */
 async function fetchAllActivities(token: string): Promise<StravaActivity[]> {
-  const maxPages = 10; // Fetch up to 10 pages in parallel
-  const promises: Promise<StravaActivity[]>[] = [];
+    const maxPages = 10; // Fetch up to 10 pages in parallel
+    const promises: Promise<StravaActivity[]>[] = [];
 
-  for (let page = 1; page <= maxPages; page++) {
-    promises.push(fetchActivitiesPage(token, page));
-  }
-
-  try {
-    const results = await Promise.all(promises);
-    const allActivities: StravaActivity[] = [];
-    
-    for (const activities of results) {
-      if (activities.length > 0) {
-        allActivities.push(...activities);
-      }
+    for (let page = 1; page <= maxPages; page++) {
+        promises.push(fetchActivitiesPage(token, page));
     }
 
-    return allActivities;
-  } catch (error) {
-    console.error('Error fetching activities:', error);
-    throw error;
-  }
+    try {
+        const results = await Promise.all(promises);
+        const allActivities: StravaActivity[] = [];
+
+        for (const activities of results) {
+            if (activities.length > 0) {
+                allActivities.push(...activities);
+            }
+        }
+
+        return allActivities;
+    } catch (error) {
+        console.error('Error fetching activities:', error);
+        throw error;
+    }
 }
 
 /**
  * Filter and sort activities by keyword and date
  */
 function filterAndSortActivities(activities: StravaActivity[]): StravaActivity[] {
-  const filtered = activities.filter(activity => {
-    const name = (activity.name || '').toLowerCase();
-    const description = (activity.description || '').toLowerCase();
-    return name.includes('terminus') || description.includes('terminus');
-  });
+    const filtered = activities.filter(activity => {
+        const name = (activity.name || '').toLowerCase();
+        const description = (activity.description || '').toLowerCase();
+        return name.includes('terminus') || description.includes('terminus');
+    });
 
-  // Sort by start_date descending (most recent first)
-  filtered.sort((a, b) => {
-    const dateA = a.start_date || '';
-    const dateB = b.start_date || '';
-    return dateA > dateB ? -1 : dateA < dateB ? 1 : 0;
-  });
+    // Sort by start_date descending (most recent first)
+    filtered.sort((a, b) => {
+        const dateA = a.start_date || '';
+        const dateB = b.start_date || '';
+        if (dateA > dateB) return -1;
+        if (dateA < dateB) return 1;
+        return 0;
+    });
 
-  return filtered;
+    return filtered;
 }
 
 /**
  * Main function to fetch and save activities
  */
 async function main() {
-  const accessToken = process.env.STRAVA_ACCESS_TOKEN;
+    const accessToken = await getAccessToken();
 
-  if (!accessToken) {
-    console.error('Error: STRAVA_ACCESS_TOKEN environment variable is required');
-    process.exit(1);
-  }
+    if (!accessToken) {
+        console.error('Error: STRAVA_ACCESS_TOKEN environment variable is required');
+        process.exit(1);
+    }
 
-  try {
-    console.log('Fetching activities from Strava API...');
-    const allActivities = await fetchAllActivities(accessToken);
-    console.log(`Fetched ${allActivities.length} total activities`);
+    try {
+        console.log('Fetching activities from Strava API...');
+        const allActivities = await fetchAllActivities(accessToken);
+        console.log(`Fetched ${allActivities.length} total activities`);
 
-    const filteredActivities = filterAndSortActivities(allActivities);
-    console.log(`Filtered to ${filteredActivities.length} activities with "terminus" keyword`);
+        const filteredActivities = filterAndSortActivities(allActivities);
+        console.log(`Filtered to ${filteredActivities.length} activities with "terminus" keyword`);
 
-    // Save to static/activities.json
-    const outputPath = join(__dirname, '..', 'static', 'activities.json');
-    writeFileSync(outputPath, JSON.stringify(filteredActivities, null, 2));
-    console.log(`Activities saved to ${outputPath}`);
+        // Save to static/activities.json
+        const outputPath = join(__dirname, '..', 'static', 'activities.json');
+        writeFileSync(outputPath, JSON.stringify(filteredActivities, null, 2));
+        console.log(`Activities saved to ${outputPath}`);
 
-  } catch (error) {
-    console.error('Error:', error);
-    process.exit(1);
-  }
+    } catch (error) {
+        console.error('Error:', error);
+        process.exit(1);
+    }
 }
 
 // Run the main function


### PR DESCRIPTION
This pull request refactors the Strava activities fetching workflow to use OAuth refresh tokens for access token management, improving security and compliance with Strava's authentication requirements. The main changes include updating the GitHub Actions workflow to use client credentials and refresh tokens, and adding logic to dynamically fetch the access token in the script.

**Authentication and environment variable updates:**

* Updated `.github/workflows/update-activities.yaml` to use `STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET`, and `STRAVA_REFRESH_TOKEN` instead of a static access token for fetching Strava activities.

**Script improvements for token management:**

* Added a new `getAccessToken` function in `scripts/fetch-activities.ts` to obtain an access token using client credentials and a refresh token via the Strava API.
* Changed the main function in `scripts/fetch-activities.ts` to dynamically fetch the access token using the new method instead of relying on a static environment variable.

**Minor code style and logic improvements:**

* Improved sorting logic in `filterAndSortActivities` for clarity and correctness.
* Minor import formatting fix in `scripts/fetch-activities.ts`.