### PR TITLE
Add config path for labeler and fetch activities on push

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - name: Pull Request Labeler
         uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yaml

--- a/.github/workflows/update-activities.yaml
+++ b/.github/workflows/update-activities.yaml
@@ -1,6 +1,9 @@
 name: Update Strava Activities
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     # Run every Sunday at 23:00 GMT (11 PM)
     - cron: '0 23 * * 0'


### PR DESCRIPTION
This pull request introduces minor configuration updates to GitHub Actions workflows, improving automation and reliability.

Workflow configuration improvements:

* [`.github/workflows/labeler.yaml`](diffhunk://#diff-5035e5e1050fac468f91ee7ad13264a79ef3e6e08a52af2110801aced423737dR15-R16): Explicitly sets the `configuration-path` for the labeler action to use `.github/labeler.yaml`, ensuring the correct label configuration file is referenced.
* [`.github/workflows/update-activities.yaml`](diffhunk://#diff-1dc848a0d011d1e6174373224f731a4ed26f42cd9c8ee61a9b61fe972d29ced1R4-R6): Adds a trigger to run the workflow on pushes to the `main` branch, in addition to the existing scheduled run, so updates are processed immediately after changes.