### PR TITLE
Use relative paths for images and minor workflow improvements

### DIFF
--- a/.github/workflows/update-activities.yaml
+++ b/.github/workflows/update-activities.yaml
@@ -9,6 +9,11 @@ on:
     - cron: '0 23 * * 0'
   workflow_dispatch:
 
+# Prevent overlapping runs (manual + scheduled) for same workflow
+concurrency:
+  group: update-activities
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pages: write
@@ -38,27 +43,26 @@ jobs:
           STRAVA_REFRESH_TOKEN: ${{ secrets.STRAVA_REFRESH_TOKEN }}
         run: npm run fetch-activities
         
-      - name: Upload activities artifact
+      - name: Upload site artifact
         uses: actions/upload-artifact@v4
         with:
-          name: activities-static
+          name: site-static # renamed from activities-static (entire site, not only activities)
           path: static
+          if-no-files-found: error
+          retention-days: 1
 
   deploy-pages:
     needs: update-activities
     runs-on: ubuntu-latest
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        
       - name: Setup Pages
         uses: actions/configure-pages@v5
         
-      - name: Download activities artifact
+      - name: Download site artifact
         uses: actions/download-artifact@v5
         with:
-          name: activities-static
+          name: site-static
           path: static
 
       - name: Upload pages artifact

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The site features automated data fetching, parallel API calls, and an interactiv
 - **No user authentication required** - data is pre-fetched and served statically
 - **Unit tests** (Vitest) for core data logic and API helper functions
 - **CI workflow** runs tests automatically on pull requests
+- **Concurrency control** prevents overlapping update/deploy runs
 
 ## Architecture
 - **Frontend**: Static HTML/CSS/JavaScript served via GitHub Pages
@@ -100,7 +101,10 @@ npx vitest
 ## Continuous Integration (CI)
 - **Workflow**: `.github/workflows/test.yaml` runs on pull requests (open, reopen, synchronize, label) and executes the Vitest suite.
 - **Strava credentials not required** for tests (fetch is mocked).
-- **Scheduled fetch & deploy**: `.github/workflows/update-activities.yaml` handles weekly data refresh and Pages deployment using an artifact (the generated `activities.json` is not committed; it is packaged and deployed directly).
+- **Scheduled fetch & deploy**: `.github/workflows/update-activities.yaml` handles weekly data refresh and Pages deployment.
+- **Page deployment artifact name**: `site-static` (contains the entire `static/` directory including `index.html`, images, and `activities.json`).
+- **No duplicate runs**: Concurrency group `update-activities` prevents overlapping scheduled/manual executions.
+- The generated `activities.json` is not committed; it is produced during the workflow and shipped inside the deployment artifact.
 
 ## User Interface
 The web UI displays:
@@ -116,7 +120,7 @@ The web UI displays:
 1. **Workflow runs** (cron or manual) → refresh Strava token → parallel fetch up to 10 pages.
 2. **Filtering**: Only activities after 22 Mar 2025 containing keyword "terminus" in name or description.
 3. **Output**: Filtered list written to `static/activities.json` in the runner workspace.
-4. **Artifact**: `static` folder uploaded; deployment job publishes it to Pages.
+4. **Artifact**: Entire `static` folder uploaded as `site-static`; deployment job publishes it to Pages.
 5. **Frontend**: Static site fetches `activities.json` client-side to render UI.
 
 ## Configuration
@@ -127,7 +131,7 @@ The web UI displays:
 - **Tests**: Add more cases under `scripts/*.test.ts` (Vitest auto-detects by pattern).
 
 ## Project Structure
-- `.github/workflows/update-activities.yaml` – Scheduled Strava fetch & deploy
+- `.github/workflows/update-activities.yaml` – Scheduled Strava fetch & deploy (artifact: `site-static`)
 - `.github/workflows/test.yaml` – PR test CI
 - `scripts/fetch-activities.ts` – Strava fetch & processing (ESM / NodeNext)
 - `scripts/fetch-activities.test.ts` – Unit tests (Vitest, mocked fetch)

--- a/static/index.html
+++ b/static/index.html
@@ -29,14 +29,16 @@
                 <h1>Prateek's Tube Challenge</h1>
             </div>
             <a class="follow-strava" href="https://www.strava.com/athletes/111956132" target="_blank" rel="noopener noreferrer" aria-label="Follow me on Strava">
-                <img src="/static/follow-me-on-strava.png" alt="Follow me on Strava" />
+                <!-- Use relative path so it works under GitHub Pages project base path -->
+                <img src="follow-me-on-strava.png" alt="Follow me on Strava" />
             </a>
         </div>
         <div class="tfl-line"></div>
     </header>
     <main>
         <section id="cycle-image-container">
-            <img src="/static/cycle.png" alt="Cycle" class="cycle-image" />
+            <!-- Relative path for GitHub Pages -->
+            <img src="cycle.png" alt="Cycle" class="cycle-image" />
         </section>
         <!-- Removed login section as it's now in the header -->
         <div id="loader" hidden>Loading activities...</div>


### PR DESCRIPTION
This pull request introduces improvements to concurrency control in the GitHub Actions workflow and clarifies artifact naming and deployment details. The changes prevent overlapping workflow runs, rename the deployment artifact to better reflect its contents, and update documentation and asset paths for better compatibility with GitHub Pages.

**Workflow improvements:**

* Added a `concurrency` group (`update-activities`) to `.github/workflows/update-activities.yaml` to prevent overlapping scheduled and manual runs.

**Artifact and deployment updates:**

* Renamed the artifact from `activities-static` to `site-static` in the workflow, updated upload/download steps, and set stricter upload parameters to ensure the entire static site is deployed.

**Documentation updates:**

* Updated `README.md` to document concurrency control, clarify the new artifact name (`site-static`), and explain that duplicate runs are prevented and the deployment artifact contains the full static site. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R107) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R123) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R134)

**Frontend asset path fixes:**

* Changed image paths in `static/index.html` from absolute (`/static/...`) to relative (`...`) to ensure assets load correctly under GitHub Pages project subpaths.