### PR TITLE
Display rides left aligned for table view

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -13,6 +13,7 @@
 const tableCellStyle = "padding:8px;border:1px solid #ccc;text-align:center;";
 const tableCellStyleLeft = "padding:8px;border:1px solid #ccc;";
 const tableCellStyleNoWrap = "padding:8px;border:1px solid #ccc;text-align:center;white-space:nowrap;";
+const tableCellStyleNoWrapLeft = "padding:8px;border:1px solid #ccc;text-align:left;white-space:nowrap;";
 
 // Application constants
 const ROAD_THRESHOLD_PX = 10; // Threshold in pixels for road visibility detection
@@ -215,7 +216,7 @@ function renderTableView() {
         const { distance, time, speed, elevation, date } = formatActivityMeta(a);
         return `<tr>
             <td style="${tableCellStyle}">${i + 1}</td>
-            <td style="${tableCellStyleNoWrap}"><a href="https://www.strava.com/activities/${a.id}" target="_blank" rel="noopener" style="color:#0019a8;text-decoration:underline;">${a.name}</a></td>
+            <td style="${tableCellStyleNoWrapLeft}"><a href="https://www.strava.com/activities/${a.id}" target="_blank" rel="noopener" style="color:#0019a8;text-decoration:underline;">${a.name}</a></td>
             <td style="${tableCellStyleNoWrap}">${date}</td>
             <td style="${tableCellStyleNoWrap}">${distance}</td>
             <td style="${tableCellStyleNoWrap}">${time}</td>


### PR DESCRIPTION
This pull request makes a minor improvement to the table view styling in `static/script.js`. The most notable change is the introduction of a new cell style for left-aligned, no-wrap table cells and its application to the activity name column.

Table view styling update:

* Added `tableCellStyleNoWrapLeft` for left-aligned, no-wrap table cells in `static/script.js`.
* Updated the activity name column in the `renderTableView` function to use the new left-aligned style, improving readability for long activity names.