### PR TITLE
Fix tabular display for mobile browsers

### DIFF
--- a/static/css/header.css
+++ b/static/css/header.css
@@ -29,6 +29,7 @@
     color: var(--text-primary);
     letter-spacing: -0.02em;
     margin: 0;
+    min-width: 0;
 }
 
 /* ---- Strava badge ---- */

--- a/static/css/header.css
+++ b/static/css/header.css
@@ -62,6 +62,11 @@
 /* ---- Challenge tab strip ---- */
 
 .challenge-tabs {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-surface);
+}
+
+.challenge-tabs-inner {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -69,8 +74,6 @@
     margin: 0 auto;
     padding: 0.6rem 2rem;
     gap: 0.75rem;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-surface);
 }
 
 .challenge-tabs-list {
@@ -130,13 +133,16 @@
 
 @media (max-width: 700px) {
     .site-header-content,
-    .challenge-tabs {
+    .challenge-tabs-inner {
         padding-left: 1rem;
         padding-right: 1rem;
     }
 
     .site-title {
         font-size: 1rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .follow-strava img {

--- a/static/css/table.css
+++ b/static/css/table.css
@@ -125,6 +125,6 @@
 }
 @media (max-width: 700px) {
     #table-view {
-        padding: 0 0.5rem;
+        padding: 0;
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -31,13 +31,15 @@
 
     <!-- Challenge detail: back-link row (shown only in detail view) -->
     <div id="challenge-detail-nav" class="challenge-tabs" role="navigation" aria-label="Challenge navigation" hidden>
-        <div class="challenge-detail-header">
-            <button type="button" class="back-link" id="back-to-challenges">&#8592; All Challenges</button>
-            <span class="detail-header-sep">|</span>
-            <span class="challenge-detail-title" id="challenge-detail-title"></span>
+        <div class="challenge-tabs-inner">
+            <div class="challenge-detail-header">
+                <button type="button" class="back-link" id="back-to-challenges">&#8592; All Challenges</button>
+                <span class="detail-header-sep">|</span>
+                <span class="challenge-detail-title" id="challenge-detail-title"></span>
+            </div>
+            <div class="challenge-tabs-list" style="display:none;"></div>
+            <span class="view-toggle"><button id="toggle-table-view"></button></span>
         </div>
-        <div class="challenge-tabs-list" style="display:none;"></div>
-        <span class="view-toggle"><button id="toggle-table-view"></button></span>
     </div>
 
     <!-- Challenge detail: activity content -->

--- a/static/index.html
+++ b/static/index.html
@@ -38,7 +38,7 @@
                 <span class="challenge-detail-title" id="challenge-detail-title"></span>
             </div>
             <div class="challenge-tabs-list" style="display:none;"></div>
-            <span class="view-toggle"><button id="toggle-table-view"></button></span>
+            <span class="view-toggle"><button type="button" id="toggle-table-view"></button></span>
         </div>
     </div>
 


### PR DESCRIPTION
This pull request refactors the header and challenge tab layout for improved styling and mobile responsiveness. The main changes include introducing a new wrapper for the challenge tabs, adjusting padding and overflow behaviors for better mobile display, and updating the HTML structure to match the new CSS.

**Header and Challenge Tabs Refactor:**

* Added a new `.challenge-tabs-inner` wrapper in both HTML and CSS to better separate styling concerns and improve layout flexibility. (`static/index.html` [[1]](diffhunk://#diff-3e8602c86d6cf04a5c74b954f9f957b652617102cf8f4b647fe46989f480861dR34) [[2]](diffhunk://#diff-3e8602c86d6cf04a5c74b954f9f957b652617102cf8f4b647fe46989f480861dR43); `static/css/header.css` [[3]](diffhunk://#diff-81a72f086382df100cf688e365f13d471e7bfbc09005213cb882743ac30b67a7R65-L73)
* Moved `border-bottom` and `background` styles from `.challenge-tabs` to `.challenge-tabs-inner` for more consistent styling. (`static/css/header.css` [static/css/header.cssR65-L73](diffhunk://#diff-81a72f086382df100cf688e365f13d471e7bfbc09005213cb882743ac30b67a7R65-L73))

**Mobile Responsiveness Improvements:**

* Adjusted padding for `.challenge-tabs-inner` and `.site-header-content` at mobile widths, and set `.site-title` to use ellipsis for overflow, preventing text wrapping issues on small screens. (`static/css/header.css` [static/css/header.cssL133-R145](diffhunk://#diff-81a72f086382df100cf688e365f13d471e7bfbc09005213cb882743ac30b67a7L133-R145))
* Removed extra horizontal padding from `#table-view` at mobile widths for a more compact table display. (`static/css/table.css` [static/css/table.cssL128-R128](diffhunk://#diff-38e4eb06dc7b09cda9bf7e7e0a0a27a9bed6d0376a8f97abc0cb4e05a4834095L128-R128))