### PR TITLE
Use gradient input for table and tiles from challenges

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -10,6 +10,10 @@
     --bg-surface: #1a1a2e;
     --bg-surface-hover: #22223a;
 
+    /* Gradient tint - overridden per-challenge by script.js */
+    --gradient-from: #1a1a2e;
+    --gradient-to:   #22223a;
+
     /* Accent colours */
     --accent-orange: #fc4c02;
     --accent-red: #e32017;

--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -29,7 +29,7 @@
 /* ---- Card component ---- */
 
 .activity {
-    background: var(--bg-surface);
+    background: color-mix(in srgb, var(--gradient-from) 25%, var(--bg-surface));
     border: 1px solid var(--border);
     border-left: 3px solid transparent;
     border-radius: var(--card-radius);
@@ -45,7 +45,7 @@
 }
 
 .activity:hover {
-    background: var(--bg-surface-hover);
+    background: color-mix(in srgb, var(--gradient-to) 35%, var(--bg-surface));
     border-left-color: var(--accent-orange);
 }
 

--- a/static/css/table.css
+++ b/static/css/table.css
@@ -78,8 +78,8 @@
 
 /* Ride name links */
 #table-view table td.ride-name-col a {
-    color: var(--accent-cyan) !important;
-    text-decoration: none;
+    color: var(--gradient-to) !important;
+    text-decoration: underline;
 }
 
 #table-view table td.ride-name-col a:hover {

--- a/static/css/table.css
+++ b/static/css/table.css
@@ -18,20 +18,20 @@
 /* Wrapper divs injected by script.js */
 #table-view > div,
 #table-view > div > div {
-    background: var(--bg-primary) !important;
+    background: color-mix(in srgb, var(--gradient-from) 18%, var(--bg-primary)) !important;
 }
 
 #table-view table {
     width: 100%;
     border-collapse: collapse;
-    background: var(--bg-primary) !important;
+    background: color-mix(in srgb, var(--gradient-from) 18%, var(--bg-primary)) !important;
     margin: 0 auto;
     table-layout: auto;
 }
 
 /* Header row - override inline background set by script.js */
 #table-view table thead tr {
-    background: var(--bg-surface) !important;
+    background: color-mix(in srgb, var(--gradient-from) 35%, var(--bg-primary)) !important;
 }
 
 #table-view table th {
@@ -39,7 +39,7 @@
     font-weight: 700;
     font-size: 0.85rem;
     color: var(--text-primary) !important;
-    background: var(--bg-surface) !important;
+    background: color-mix(in srgb, var(--gradient-from) 35%, var(--bg-primary)) !important;
     padding: 0.75rem 0.75rem !important;
     border: 1px solid var(--border) !important;
     text-align: left;
@@ -53,7 +53,7 @@
 }
 
 #table-view table th[role="button"]:hover {
-    background: var(--bg-surface-hover) !important;
+    background: color-mix(in srgb, var(--gradient-to) 40%, var(--bg-primary)) !important;
 }
 
 /* Body rows */
@@ -73,7 +73,7 @@
 
 /* Alternating row tint */
 #table-view table tbody tr:nth-child(even) td {
-    background: rgba(255, 255, 255, 0.02) !important;
+    background: color-mix(in srgb, var(--gradient-from) 8%, transparent) !important;
 }
 
 /* Ride name links */
@@ -88,7 +88,7 @@
 
 /* Totals row - last row in tbody, override inline background */
 #table-view table tbody tr:last-child td {
-    background: var(--bg-surface) !important;
+    background: color-mix(in srgb, var(--gradient-from) 35%, var(--bg-primary)) !important;
     font-family: 'Space Grotesk', sans-serif;
     font-weight: 700;
     border-left: none !important;

--- a/static/css/table.css
+++ b/static/css/table.css
@@ -29,7 +29,7 @@
     table-layout: auto;
 }
 
-/* Header row - override inline background set by script.js */
+/* Header row */
 #table-view table thead tr {
     background: color-mix(in srgb, var(--gradient-from) 35%, var(--bg-primary)) !important;
 }
@@ -86,7 +86,7 @@
     text-decoration: underline;
 }
 
-/* Totals row - last row in tbody, override inline background */
+/* Totals row - last row in tbody */
 #table-view table tbody tr:last-child td {
     background: color-mix(in srgb, var(--gradient-from) 35%, var(--bg-primary)) !important;
     font-family: 'Space Grotesk', sans-serif;

--- a/static/script.js
+++ b/static/script.js
@@ -375,7 +375,7 @@ function renderTableView() {
         const { distance, time, speed, elevation, date } = formatActivityMeta(a);
         return `<tr>
             <td style="${tableCellStyle}">${i + 1}</td>
-            <td class="ride-name-col" style="${tableCellStyleNoWrapLeft}"><a href="https://www.strava.com/activities/${a.id}" target="_blank" rel="noopener" style="color:#0019a8;text-decoration:underline;">${a.name}</a></td>
+            <td class="ride-name-col" style="${tableCellStyleNoWrapLeft}"><a href="https://www.strava.com/activities/${a.id}" target="_blank" rel="noopener">${a.name}</a></td>
             <td class="date-col" style="${tableCellStyleNoWrap}">${date}</td>
             <td class="distance-col" style="${tableCellStyleNoWrap}">${distance}</td>
             <td class="time-col" style="${tableCellStyleNoWrap}">${time}</td>

--- a/static/script.js
+++ b/static/script.js
@@ -158,6 +158,10 @@ function router() {
     showView('challenge');
     elements.detailTitle.textContent = challenge.name;
 
+    // Expose gradient colours as CSS variables for tinting cards and table
+    document.documentElement.style.setProperty('--gradient-from', challenge.gradient[0]);
+    document.documentElement.style.setProperty('--gradient-to',   challenge.gradient[1]);
+
     // Cancel any in-flight fetch from a previous navigation
     if (currentFetchController) {
         currentFetchController.abort();
@@ -354,7 +358,7 @@ function renderTableView() {
 
     const tableHeader = `
         <thead>
-            <tr style="background:#e6f6fb;">
+            <tr>
                 <th style="${tableCellStyle}">#</th>
                 <th class="ride-name-col" style="${tableCellStyleLeft}">Ride Name</th>
                 <th class="date-col" id="sort-date" ${getSortableColumnProps('date')} style="${tableCellStyleLeft};cursor:pointer;user-select:none;white-space:nowrap;">📅 Date ${getSortIcon('date')}</th>
@@ -382,7 +386,7 @@ function renderTableView() {
 
     // Build table footer with totals
     const tableFooter = `
-        <tr style="background:#f5f5f5;">
+        <tr>
             <td style="${tableCellStyle};font-weight:bold;"></td>
             <td class="ride-name-col" style="${tableCellStyle};font-weight:bold;">Total</td>
             <td class="date-col" style="${tableCellStyle};font-weight:bold;"></td>
@@ -397,7 +401,7 @@ function renderTableView() {
     elements.tableView.innerHTML = `
         <div style="margin:0 auto;width:100%;">
             <div>
-                <table style="width:100%;border-collapse:collapse;background:#fff;margin:0 auto;">
+                <table style="width:100%;border-collapse:collapse;margin:0 auto;">
                     ${tableHeader}
                     <tbody>
                         ${tableRows}


### PR DESCRIPTION
This pull request introduces a dynamic gradient tint system for the card and table UI components, allowing their backgrounds and accents to be themed per challenge. The system works by exposing gradient colors from the challenge data as CSS variables, which are then used in the CSS via `color-mix` for more visually appealing and flexible styling. Several hardcoded color values and inline styles are removed in favor of this new approach.

**Dynamic gradient theming:**

* [`static/script.js`](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3R161-R164): Sets CSS variables `--gradient-from` and `--gradient-to` based on the current challenge's gradient, making the tint customizable for each challenge.
* [`static/css/base.css`](diffhunk://#diff-4d95ed2762a2b6ec4b2f9be93a2523d0ba59a5e563085c3102bdfff4bfb38f0eR13-R16): Defines the new gradient CSS variables with default values.

**Cards and table background improvements:**

* [`static/css/cards.css`](diffhunk://#diff-6deb5614c709e954a3f81623b5e3b8543d212cac989d1c4925108e08fe762ca6L32-R32): Updates card backgrounds to use the gradient tint via `color-mix`, both in normal and hover states. [[1]](diffhunk://#diff-6deb5614c709e954a3f81623b5e3b8543d212cac989d1c4925108e08fe762ca6L32-R32) [[2]](diffhunk://#diff-6deb5614c709e954a3f81623b5e3b8543d212cac989d1c4925108e08fe762ca6L48-R48)
* [`static/css/table.css`](diffhunk://#diff-38e4eb06dc7b09cda9bf7e7e0a0a27a9bed6d0376a8f97abc0cb4e05a4834095L21-R42): Refactors table backgrounds, header, alternating rows, and totals row to use the gradient tint, replacing previous static or semi-transparent backgrounds. [[1]](diffhunk://#diff-38e4eb06dc7b09cda9bf7e7e0a0a27a9bed6d0376a8f97abc0cb4e05a4834095L21-R42) [[2]](diffhunk://#diff-38e4eb06dc7b09cda9bf7e7e0a0a27a9bed6d0376a8f97abc0cb4e05a4834095L56-R56) [[3]](diffhunk://#diff-38e4eb06dc7b09cda9bf7e7e0a0a27a9bed6d0376a8f97abc0cb4e05a4834095L76-R82) [[4]](diffhunk://#diff-38e4eb06dc7b09cda9bf7e7e0a0a27a9bed6d0376a8f97abc0cb4e05a4834095L91-R91)

**Simplification and consistency:**

* [`static/script.js`](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3L357-R361): Removes hardcoded inline background colors from table header and footer rows, relying on CSS for consistent theming. [[1]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3L357-R361) [[2]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3L385-R389) [[3]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3L400-R404)
* `static/script.js`/`static/css/table.css`: Updates ride name link color to use the gradient accent and ensures underline styling, removing previous hardcoded color. [[1]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3L374-R378) [[2]](diffhunk://#diff-38e4eb06dc7b09cda9bf7e7e0a0a27a9bed6d0376a8f97abc0cb4e05a4834095L76-R82)

These changes collectively make the UI more flexible and visually cohesive, with theming now controlled by challenge data rather than static values.