### PR TITLE
Make heatmaps as the default view

### DIFF
--- a/static/css/heatmap.css
+++ b/static/css/heatmap.css
@@ -62,6 +62,7 @@
     background: color-mix(in srgb, var(--gradient-from) 18%, var(--bg-surface));
     border: 1px solid var(--border);
     border-radius: var(--card-radius);
+    overflow: visible;
 }
 
 .heatmap-calendar__heading {
@@ -91,6 +92,7 @@
     gap: 3px;
     flex-wrap: wrap;
     align-items: flex-start;
+    overflow: visible;
 }
 
 .heatmap-calendar__week {
@@ -106,15 +108,10 @@
     background: color-mix(in srgb, var(--gradient-from) 30%, #000);
     cursor: default;
     flex-shrink: 0;
-    position: relative;
 }
 
-.heatmap-calendar__cell[data-tooltip]:hover::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    bottom: calc(100% + 4px);
-    left: 50%;
-    transform: translateX(-50%);
+.heatmap-tooltip {
+    position: fixed;
     background: #1a1a2e;
     color: #fff;
     font-size: 0.7rem;
@@ -123,7 +120,8 @@
     border-radius: 4px;
     border: 1px solid var(--border);
     pointer-events: none;
-    z-index: 10;
+    z-index: 9999;
+    display: none;
 }
 
 .heatmap-calendar__legend {

--- a/static/index.html
+++ b/static/index.html
@@ -42,9 +42,9 @@
             </div>
             <div class="challenge-tabs-list" style="display:none;"></div>
             <span class="view-toggle">
-                <button type="button" id="view-btn-card" class="view-btn active">Cards</button>
+                <button type="button" id="view-btn-heatmap" class="view-btn active">Heatmap</button>
                 <button type="button" id="view-btn-table" class="view-btn">Table</button>
-                <button type="button" id="view-btn-heatmap" class="view-btn">Heatmap</button>
+                <button type="button" id="view-btn-card" class="view-btn">Cards</button>
             </span>
         </div>
     </nav>

--- a/static/script.js
+++ b/static/script.js
@@ -244,8 +244,6 @@ async function fetchActivities(challenge) {
             return;
         }
 
-        renderCardView(activities);
-
         const savedMode = localStorage.getItem('viewMode');
         const mode = (savedMode === 'table' || savedMode === 'card') ? savedMode : 'heatmap';
         switchView(mode);
@@ -468,6 +466,7 @@ function renderCardView(activities) {
 const _calTooltip = (() => {
     const el = document.createElement('div');
     el.className = 'heatmap-tooltip';
+    el.style.display = 'none';
     document.body.appendChild(el);
 
     document.addEventListener('mousemove', e => {
@@ -513,10 +512,7 @@ function renderHeatmapView(activities) {
             const cell = e.target.closest('.heatmap-calendar__cell[data-tooltip]');
             if (cell) _calTooltip.show(cell.dataset.tooltip);
         });
-        calendarEl.addEventListener('mouseout', e => {
-            if (!e.target.closest('.heatmap-calendar__cell[data-tooltip]')) return;
-            _calTooltip.hide();
-        });
+        calendarEl.addEventListener('mouseleave', () => _calTooltip.hide());
     }
 
     // ── Initialise or reinitialise Leaflet map ──────────────────────────
@@ -753,7 +749,9 @@ function switchView(mode) {
     elements.btnHeatmap.classList.toggle('active', mode === 'heatmap');
 
     // Render the selected view
-    if (mode === 'table') {
+    if (mode === 'card') {
+        renderCardView(activitiesData);
+    } else if (mode === 'table') {
         renderTableView();
     } else if (mode === 'heatmap') {
         renderHeatmapView(activitiesData);

--- a/static/script.js
+++ b/static/script.js
@@ -247,7 +247,7 @@ async function fetchActivities(challenge) {
         renderCardView(activities);
 
         const savedMode = localStorage.getItem('viewMode');
-        const mode = (savedMode === 'table' || savedMode === 'heatmap') ? savedMode : 'card';
+        const mode = (savedMode === 'table' || savedMode === 'card') ? savedMode : 'heatmap';
         switchView(mode);
 
     } catch (error) {
@@ -461,6 +461,27 @@ function renderCardView(activities) {
 // Heatmap view
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Calendar tooltip (body-level, never clipped by ancestors)
+// ---------------------------------------------------------------------------
+
+const _calTooltip = (() => {
+    const el = document.createElement('div');
+    el.className = 'heatmap-tooltip';
+    document.body.appendChild(el);
+
+    document.addEventListener('mousemove', e => {
+        if (el.style.display === 'none') return;
+        el.style.left = (e.clientX + 12) + 'px';
+        el.style.top  = (e.clientY + 12) + 'px';
+    });
+
+    return {
+        show(text) { el.textContent = text; el.style.display = 'block'; },
+        hide()     { el.style.display = 'none'; }
+    };
+})();
+
 /**
  * Render the heatmap view: route map + stats row + distance calendar.
  * @param {Activity[]} activities
@@ -484,6 +505,19 @@ function renderHeatmapView(activities) {
             ${buildCalendarHTML(activities)}
         </div>
     `;
+
+    // ── Calendar tooltip via event delegation ───────────────────────────
+    const calendarEl = section.querySelector('.heatmap-calendar__grid');
+    if (calendarEl) {
+        calendarEl.addEventListener('mouseover', e => {
+            const cell = e.target.closest('.heatmap-calendar__cell[data-tooltip]');
+            if (cell) _calTooltip.show(cell.dataset.tooltip);
+        });
+        calendarEl.addEventListener('mouseout', e => {
+            if (!e.target.closest('.heatmap-calendar__cell[data-tooltip]')) return;
+            _calTooltip.hide();
+        });
+    }
 
     // ── Initialise or reinitialise Leaflet map ──────────────────────────
     if (leafletMap) {
@@ -646,7 +680,7 @@ function buildCalendarHTML(activities) {
 
     const cellTitle = (key, dist) => {
         if (!key) return '';
-        const label = dist > 0 ? `${key}: ${(dist / 1000).toFixed(1)} km` : `${key}: Rest day`;
+        const label = dist > 0 ? `${key}: ${(dist / 1000).toFixed(1)} km` : key;
         return `data-tooltip="${label}" aria-label="${label}"`;
     };
 


### PR DESCRIPTION
This pull request updates the heatmap calendar's tooltip system to use a fixed-position tooltip element, ensuring tooltips are never clipped by ancestor containers. It also adjusts the default view to "Heatmap" instead of "Cards" and makes minor improvements to the calendar cell tooltip content.

**Heatmap Tooltip Refactor and Improvements:**

* Replaces the old CSS-based tooltip (using `::after` and `position: absolute`) with a new JavaScript-driven tooltip element (`.heatmap-tooltip`) that is appended to the document body and positioned with the mouse, preventing clipping issues. [[1]](diffhunk://#diff-78027b1a6206cb7ef0a61f45e3c41d821b8cf992c86a201ff2a47b2ebd5c8a05L109-R114) [[2]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3R464-R484) [[3]](diffhunk://#diff-78027b1a6206cb7ef0a61f45e3c41d821b8cf992c86a201ff2a47b2ebd5c8a05L126-R124)
* Adds event delegation for tooltip display on the calendar grid, showing and hiding the tooltip on mouseover/mouseout.
* Updates CSS for `.heatmap-tooltip` to use `position: fixed`, a higher `z-index`, and default `display: none`. Also sets `overflow: visible` on relevant containers to avoid clipping. [[1]](diffhunk://#diff-78027b1a6206cb7ef0a61f45e3c41d821b8cf992c86a201ff2a47b2ebd5c8a05R65) [[2]](diffhunk://#diff-78027b1a6206cb7ef0a61f45e3c41d821b8cf992c86a201ff2a47b2ebd5c8a05R95) [[3]](diffhunk://#diff-78027b1a6206cb7ef0a61f45e3c41d821b8cf992c86a201ff2a47b2ebd5c8a05L126-R124)

**UI/UX Adjustments:**

* Changes the default view to "Heatmap" (instead of "Cards") both in the navigation button order and in the initial view mode logic. [[1]](diffhunk://#diff-3e8602c86d6cf04a5c74b954f9f957b652617102cf8f4b647fe46989f480861dL45-R47) [[2]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3L250-R250)
* Simplifies the tooltip text for rest days in the calendar, showing only the date instead of "Rest day".